### PR TITLE
Added Listener Interface

### DIFF
--- a/models/interpreters/BattleShipBotAi.java
+++ b/models/interpreters/BattleShipBotAi.java
@@ -1,9 +1,17 @@
 package battleship.models.interpreters;
+/* @author Area 51 Block Party:
+ * Christopher Brantley, Andrew Braswell
+ * Last Updated: 11/24/2019
+ */
 
-public class BattleShipBotAi {
+import battleship.tools.Listener;
+
+public class BattleShipBotAi implements Listener {
 
     public BattleShipBotAi(int _difficulty) {
     }
+
+    @Override
     public void catchEvent(Object _event) {
     }
 }

--- a/models/interpreters/BattleShipFleetLocalInterpreter.java
+++ b/models/interpreters/BattleShipFleetLocalInterpreter.java
@@ -1,15 +1,16 @@
 package battleship.models.interpreters;
 
 /* @author Area 51 Block Party:
- * Christopher Brantley
- * Last Updated: 11/20/2019
+ * Christopher Brantley, Andrew Braswell
+ * Last Updated: 11/24/2019
  */
 
 import battleship.models.BattleShipGame;
 import battleship.models.BattleShipPlayer;
+import battleship.tools.Listener;
 import battleship.tools.events.*;
 
-public class BattleShipFleetLocalInterpreter{
+public class BattleShipFleetLocalInterpreter implements Listener {
 
     BattleShipPlayer player;
 
@@ -17,6 +18,7 @@ public class BattleShipFleetLocalInterpreter{
         this.player = _player;
     }
 
+    @Override
     public void catchEvent(Object _event) {
         if (_event instanceof MoveShipIncrementEvent) {
             MoveShipIncrementEvent event = (MoveShipIncrementEvent)_event;

--- a/models/interpreters/BattleShipGameInterpreter.java
+++ b/models/interpreters/BattleShipGameInterpreter.java
@@ -1,8 +1,9 @@
+package battleship.models.interpreters;
+
 /* @author Area 51 Block Party:
  * Christopher Brantley, Andrew Braswell
  * Last Updated: 11/24/2019
  */
-package battleship.models.interpreters;
 
 import battleship.models.BattleShipGame;
 import battleship.models.BattleShipPlayer;
@@ -13,6 +14,7 @@ import battleship.tools.Listener;
 
 
 public class BattleShipGameInterpreter implements Listener {
+
     public BattleShipGameInterpreter(BattleShipGame _battleShipGame) {
         this.battleShipGame = _battleShipGame;
     }

--- a/models/interpreters/BattleShipGameInterpreter.java
+++ b/models/interpreters/BattleShipGameInterpreter.java
@@ -1,7 +1,6 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+/* @author Area 51 Block Party:
+ * Christopher Brantley, Andrew Braswell
+ * Last Updated: 11/24/2019
  */
 package battleship.models.interpreters;
 
@@ -10,17 +9,16 @@ import battleship.models.BattleShipPlayer;
 import battleship.models.Coordinate;
 import battleship.tools.events.FireAwayEvent;
 import battleship.tools.events.*;
+import battleship.tools.Listener;
 
-/**
- *
- * @author Christopher
- */
-public class BattleShipGameInterpreter {
+
+public class BattleShipGameInterpreter implements Listener {
     public BattleShipGameInterpreter(BattleShipGame _battleShipGame) {
         this.battleShipGame = _battleShipGame;
     }
     private BattleShipGame battleShipGame;
 
+    @Override
     public void catchEvent(Object _event) {
         if (_event instanceof FireAwayEvent) {
             FireAwayEvent event = (FireAwayEvent)_event;

--- a/tools/EventBus.java
+++ b/tools/EventBus.java
@@ -1,35 +1,32 @@
 package battleship.tools;
-
 /* @author Area 51 Block Party:
- * Christopher Brantley
- * Last Updated: 11/03/2019
+ * Christopher Brantley, Andrew Braswell
+ * Last Updated: 11/24/2019
  */
 
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public final class EventBus {
     public EventBus() {}
-    private ArrayList listeners = new ArrayList();
+    private ArrayList<Listener> listeners = new ArrayList();
 
     public final void throwEvent(Object _event) {
-        this.listeners.forEach(child -> {
+        this.listeners.forEach(listener -> {
             try {
-                Method catchEvent = child.getClass().getMethod("catchEvent", Object.class);
-                catchEvent.invoke(child, _event);
+                listener.catchEvent(_event);
             } catch (Exception e) {
                 Logger.getLogger(EventBus.class.getName()).log(Level.SEVERE, null, e);
             }
         });
     }
 
-    public final void addListener (Object _listener) {
+    public final void addListener (Listener _listener) {
         this.listeners.add(_listener);
     }
 
-    public final void removeListener (Object _listener) {
+    public final void removeListener (Listener _listener) {
         this.listeners.remove(_listener);
     }
 //*****************     GETTERS     *******************

--- a/tools/EventBus.java
+++ b/tools/EventBus.java
@@ -1,4 +1,5 @@
 package battleship.tools;
+
 /* @author Area 51 Block Party:
  * Christopher Brantley, Andrew Braswell
  * Last Updated: 11/24/2019
@@ -9,8 +10,11 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public final class EventBus {
-    public EventBus() {}
+
     private ArrayList<Listener> listeners = new ArrayList();
+
+    public EventBus() {
+    }
 
     public final void throwEvent(Object _event) {
         this.listeners.forEach(listener -> {
@@ -29,6 +33,7 @@ public final class EventBus {
     public final void removeListener (Listener _listener) {
         this.listeners.remove(_listener);
     }
+
 //*****************     GETTERS     *******************
 
     public final ArrayList getListeners() {

--- a/tools/Listener.java
+++ b/tools/Listener.java
@@ -1,9 +1,11 @@
 package battleship.tools;
-/**
-* This interface must be implemented by all functions which listen to the EventBus.
-*
-* @author Andrew Braswell Last Updated: 11/24/2019
-*/
+
+/* @author Area 51 Block Party:
+ * Andrew Braswell
+ * Last Updated: 11/24/2019
+ * This interface must be implemented by all functions which listen to the EventBus.
+ *
+ */
 
 public interface Listener {
 

--- a/tools/Listener.java
+++ b/tools/Listener.java
@@ -1,0 +1,12 @@
+package battleship.tools;
+/**
+* This interface must be implemented by all functions which listen to the EventBus.
+*
+* @author Andrew Braswell Last Updated: 11/24/2019
+*/
+
+public interface Listener {
+
+    public void catchEvent(Object _event);
+
+}

--- a/views/interpreters/BattleShipGameViewInterpreter.java
+++ b/views/interpreters/BattleShipGameViewInterpreter.java
@@ -1,7 +1,7 @@
 package battleship.views.interpreters;
 
 /* @author Area 51 Block Party:
- * Christopher Brantley
+ * Christopher Brantley, Andrew Braswell
  * Last Updated: 11/11/2019
  * This class is the interpreter for the event bus and the shipselectionview.
  * This class will define the protocol behind what happens when an event is
@@ -9,6 +9,7 @@ package battleship.views.interpreters;
  */
 
 import battleship.tools.ViewAssets;
+import battleship.tools.Listener;
 import battleship.tools.events.*;
 import battleship.views.BattleShipGameView;
 import javafx.scene.Node;
@@ -16,12 +17,13 @@ import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.layout.GridPane;
 
-public class BattleShipGameViewInterpreter {
+public class BattleShipGameViewInterpreter implements Listener {
     public BattleShipGameViewInterpreter(BattleShipGameView battleShipGameView) {
         this.battleShipGameView = battleShipGameView;
     }
     private final BattleShipGameView battleShipGameView;
 
+    @Override
     public void catchEvent(Object _event) {
         if(_event instanceof UpdateSectorEvent) {
             UpdateSectorEvent event = ((UpdateSectorEvent)_event);

--- a/views/interpreters/BattleShipGameViewInterpreter.java
+++ b/views/interpreters/BattleShipGameViewInterpreter.java
@@ -2,7 +2,7 @@ package battleship.views.interpreters;
 
 /* @author Area 51 Block Party:
  * Christopher Brantley, Andrew Braswell
- * Last Updated: 11/11/2019
+ * Last Updated: 11/24/2019
  * This class is the interpreter for the event bus and the shipselectionview.
  * This class will define the protocol behind what happens when an event is
  * meant to be thrown to the ship selection view.

--- a/views/interpreters/BattleShipGameViewInterpreter.java
+++ b/views/interpreters/BattleShipGameViewInterpreter.java
@@ -18,10 +18,12 @@ import javafx.scene.control.Label;
 import javafx.scene.layout.GridPane;
 
 public class BattleShipGameViewInterpreter implements Listener {
+
+    private final BattleShipGameView battleShipGameView;
+
     public BattleShipGameViewInterpreter(BattleShipGameView battleShipGameView) {
         this.battleShipGameView = battleShipGameView;
     }
-    private final BattleShipGameView battleShipGameView;
 
     @Override
     public void catchEvent(Object _event) {

--- a/views/interpreters/ShipSelectionViewInterpreter.java
+++ b/views/interpreters/ShipSelectionViewInterpreter.java
@@ -1,24 +1,26 @@
 package battleship.views.interpreters;
 
 /* @author Area 51 Block Party:
- * Christopher Brantley
- * Last Updated: 11/11/2019
+ * Christopher Brantley, Andrew Braswell
+ * Last Updated: 11/24/2019
  * This class is the interpreter for the event bus and the shipselectionview.
  * This class will define the protocol behind what happens when an event is
  * meant to be thrown to the ship selection view.
  */
 
 import battleship.tools.events.*;
+import battleship.tools.Listener;
 import battleship.views.ShipSelectionView;
 import javafx.scene.Node;
 import javafx.scene.layout.GridPane;
 
-public class ShipSelectionViewInterpreter {
+public class ShipSelectionViewInterpreter implements Listener {
     public ShipSelectionViewInterpreter(ShipSelectionView shipSelectionView) {
         this.shipSelectionView = shipSelectionView;
     }
     private final ShipSelectionView shipSelectionView;
 
+    @Override
     public void catchEvent(Object _event) {
         if(_event instanceof UpdateSectorEvent) {
             UpdateSectorEvent event = ((UpdateSectorEvent)_event);

--- a/views/interpreters/ShipSelectionViewInterpreter.java
+++ b/views/interpreters/ShipSelectionViewInterpreter.java
@@ -15,13 +15,16 @@ import javafx.scene.Node;
 import javafx.scene.layout.GridPane;
 
 public class ShipSelectionViewInterpreter implements Listener {
+
+    private final ShipSelectionView shipSelectionView;
+
     public ShipSelectionViewInterpreter(ShipSelectionView shipSelectionView) {
         this.shipSelectionView = shipSelectionView;
     }
-    private final ShipSelectionView shipSelectionView;
 
     @Override
     public void catchEvent(Object _event) {
+
         if(_event instanceof UpdateSectorEvent) {
             UpdateSectorEvent event = ((UpdateSectorEvent)_event);
             int row = event.getRow();


### PR DESCRIPTION
All classes which can be added to the EventBus's <listener> array must now implement the Listener interface.  This interface just requires that all classes which implement it must have an implementation of the catchEvent() method.

This is mostly just to make the code safer.  It's no longer possible for the event bus to try to call catchEvent() on a class which does not implement it.