### PR TITLE
Made the error checking in battleship.weather more robust

### DIFF
--- a/weather/models/Weather.java
+++ b/weather/models/Weather.java
@@ -2,7 +2,7 @@ package battleship.weather.models;
 
 /* @author Area 51 Block Party:
  * Andrew Braswell
- * Last Updated: 11/27/2019
+ * Last Updated: 12/03/2019
  * This class handles all functionality related to weather.
  */
 
@@ -24,7 +24,7 @@ public class Weather {
     //Whether or not the weather object has successfully loaded the API.
     protected boolean hasData;
 
-    //Enumeratated error value.
+    //Enumerator -> error value.
     public static final int ERROR = -1;
 
     /**
@@ -72,6 +72,7 @@ public class Weather {
         this.windDirection = 0;
         this.hasData = false;
     }
+
 //*****************     GETTERS     *******************
 
     public Location getLocation () {
@@ -81,7 +82,7 @@ public class Weather {
     public String getLocationName () {
         if (this.location == null)
             return "No Location";
-        return this.location.getName() + (this.hasData? "" :" (No Data)");
+        return this.location.getName() + (this.hasData? "" : " (No Data)");
     }
 
     public int getWindDirection () {

--- a/weather/models/Weather.java
+++ b/weather/models/Weather.java
@@ -21,9 +21,19 @@ public class Weather {
     protected double windSpeed;
     //The temperature in Fahrenheit.
     protected double temperature;
+    //Whether or not the weather object has successfully loaded the API.
+    protected boolean hasData;
 
-    //Enumerator
+    //Enumeratated error value.
     public static final int ERROR = -1;
+
+    /**
+     * Creates a blank Weather object with no weather data.
+     */
+    public Weather () {
+        this.location = null;
+        this.noData();
+    }
 
     /** This method fetches weather information for a given Location using the API.
      *  @param _location A Location object.
@@ -33,11 +43,11 @@ public class Weather {
         Weather weather = new Weather();
         weather.location = _location;
         Weather.API.fetchWeatherByLocation(_location);
-        weather.windDirection = Weather.API.loadWindDirection();
-        weather.temperature = Weather.API.loadTemperature();
-        weather.windSpeed = Weather.API.loadWindSpeed();
-        if (weather.windDirection == Weather.ERROR) {
-            return null;
+        if (Weather.API.loadWindDirection() != Weather.ERROR) {
+            weather.windDirection = Weather.API.loadWindDirection();
+            weather.temperature = Weather.API.loadTemperature();
+            weather.windSpeed = Weather.API.loadWindSpeed();
+            weather.hasData = true;
         }
         return weather;
     }
@@ -53,6 +63,15 @@ public class Weather {
         return weathers;
     }
 
+    /**
+     * Sets the Weather object to have no weather data.
+     */
+    private void noData () {
+        this.temperature = 0;
+        this.windSpeed = 0;
+        this.windDirection = 0;
+        this.hasData = false;
+    }
 //*****************     GETTERS     *******************
 
     public Location getLocation () {
@@ -60,7 +79,9 @@ public class Weather {
     }
 
     public String getLocationName () {
-        return this.location.getName();
+        if (this.location == null)
+            return "No Location";
+        return this.location.getName() + (this.hasData? "" :" (No Data)");
     }
 
     public int getWindDirection () {
@@ -81,6 +102,10 @@ public class Weather {
 
     public double getYWindSpeed () {
         return this.windSpeed * Math.cos(this.windDirection);
+    }
+
+    public boolean hasData () {
+        return this.hasData;
     }
 
 }

--- a/weather/models/Weather.java
+++ b/weather/models/Weather.java
@@ -27,13 +27,6 @@ public class Weather {
     //Enumeratated error value.
     public static final int ERROR = -1;
 
-    /**
-     * Creates a blank Weather object with no weather data.
-     */
-    public Weather () {
-        this.location = null;
-        this.noData();
-    }
 
     /** This method fetches weather information for a given Location using the API.
      *  @param _location A Location object.
@@ -63,15 +56,7 @@ public class Weather {
         return weathers;
     }
 
-    /**
-     * Sets the Weather object to have no weather data.
-     */
-    private void noData () {
-        this.temperature = 0;
-        this.windSpeed = 0;
-        this.windDirection = 0;
-        this.hasData = false;
-    }
+
 //*****************     GETTERS     *******************
 
     public Location getLocation () {

--- a/weather/util/Location.java
+++ b/weather/util/Location.java
@@ -17,15 +17,44 @@ public class Location {
     public static final int NORTH_SEA = 1;
     public static final int FALKLANDS = 2;
     public static final int TONKIN = 3;
+
+    //The default name used when invalid location paramters are used.
+    private static final String DEFAULT_NAME = "Null Island";
+
     //Instance variables
     private final int latitude;
     private final int longitude;
     private final String name;
 
-    public Location (int _latitude, int _longitude, String _name) {
+    /**
+     * This constructs a location with the default values.  This is only called when makeLocation() is called with invalid parameters.
+     */
+    private Location () {
+        this.latitude = 0;
+        this.longitude = 0;
+        this.name = DEFAULT_NAME;
+    }
+
+    /**
+     * This constructs a location with the given values.  This is only called through the makeLocation() static method.
+     */
+    private Location (int _latitude, int _longitude, String _name) {
         this.latitude = _latitude;
         this.longitude = _longitude;
         this.name = _name;
+    }
+
+    /**
+     * Constructs and returns a Location object.  If the coordinate parameters are invalid, it returns the default Location object.
+     */
+    public static Location makeLocation (int _latitude, int _longitude, String _name) {
+        if (isValidCoordinate(_latitude) && isValidCoordinate(_longitude))
+            return new Location(_latitude, _longitude, _name);
+        else
+        {
+            System.out.println("Error: Invalid Location coordinate parameters");
+            return new Location();
+        }
     }
 
     /** This static method returns a Location object.  To program a new location, enumerate it above then add its case below.
@@ -35,15 +64,15 @@ public class Location {
     public static Location getLocation (int _enumLocation) {
         switch (_enumLocation) {
             case Location.MIDWAY:
-                return new Location(28, -177, "Midway Atoll");
+                return makeLocation(28, -177, "Midway Atoll");
             case Location.NORTH_SEA :
-                return new Location(56, 3, "The North Sea");
+                return makeLocation(56, 3, "The North Sea");
             case Location.FALKLANDS:
-                return new Location(-51, -57, "The Falkland Islands");
+                return makeLocation(-51, -57, "The Falkland Islands");
             case Location.TONKIN:
-                return new Location(19, 106, "The Gulf of Tonkin");
+                return makeLocation(19, 106, "The Gulf of Tonkin");
             default:
-                return new Location(0, 0, "Null Island");
+                return new Location();
         }
     }
 
@@ -57,7 +86,8 @@ public class Location {
         Location location;
         while (true) {
             location = getLocation(enumLocation);
-            if (location.name.equals("Null Island")) {
+            if (location.name.equals(DEFAULT_NAME)) {
+                locations.add(location);
                 break;
             }
             locations.add(location);
@@ -66,6 +96,14 @@ public class Location {
         return locations;
     }
 
+    /**
+     * This helper method checks whether or not a given coordinate is valid.
+     * @param _ltude Latitude or Longitude
+     * @return True if valid, false if invalid.
+     */
+    private static boolean isValidCoordinate (int _ltude) {
+        return (_ltude > -180 && _ltude < 180);
+    }
 //*****************     GETTERS     *******************
 
     public int getLatitude () {

--- a/weather/util/Location.java
+++ b/weather/util/Location.java
@@ -2,7 +2,7 @@ package battleship.weather.util;
 
 /* @author Area 51 Block Party:
  * Andrew Braswell
- * Last Updated: 11/27/2019
+ * Last Updated: 12/03/2019
  * This class enumerates locations.
  * It can be instantiated to create an object that contains information about a location.
  */
@@ -104,6 +104,7 @@ public class Location {
     private static boolean isValidCoordinate (int _ltude) {
         return (_ltude > -180 && _ltude < 180);
     }
+
 //*****************     GETTERS     *******************
 
     public int getLatitude () {

--- a/weather/weatherapp/WeatherApp.java
+++ b/weather/weatherapp/WeatherApp.java
@@ -7,13 +7,16 @@ package battleship.weather.weatherapp;
  */
 
 import java.text.DecimalFormat;
+import java.util.ArrayList;
 import battleship.weather.models.Weather;
 
 public class WeatherApp {
 
     public static void main(String[] args) {
         DecimalFormat f = new DecimalFormat("#.##");
-        for (Weather w : Weather.loadWeathersForAllLocations()) {
+        ArrayList<Weather> weathers = Weather.loadWeathersForAllLocations();
+        weathers.add(new Weather());
+        for (Weather w : weathers) {
             System.out.println("The temperature in " + w.getLocationName() + " is " + w.getTemperature() + " F.");
             System.out.println("Windspeed: " + w.getWindSpeed() + ".  Wind direction: " + w.getWindDirection());
             System.out.println("The wind is blowing " + f.format(w.getXWindSpeed()) + " mph from the west and " + f.format(w.getYWindSpeed()) + " mph from the north. \n");


### PR DESCRIPTION
Addressing what was brought up in my code review.

Location no longer has a public constructor.  Its constructors can only be accessed through the static makeLocation method which returns a "Null Island" Location when given invalid parameters.

I went ahead and made a DEFAULT_NAME constant just in case we wanted to rename "Null Island".

Null Island is now one of the locations given by getAllLocations, just for fun.

The default constructor for the Weather class now creates a blank Weather object with no data.  If the API call fails, the object stays blank and the getLocationName notes that there is no data.